### PR TITLE
ci: add jreleaser for release flow

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Basic project metadata
+project:
+  name: wallet-client-gateway
+  description: EUDIW client gateway - Backend for Frontend serving mobile and web apps
+  license: EUPL-1.2
+  copyright: 2025 Digg - The Agency for Digital Government
+  inceptionYear: 2025
+  authors:
+    - Digg - Agency for Digital Government
+  snapshot:
+    pattern: .*-SNAPSHOT
+    label: early-access
+    fullChangelog: true
+
+# GitHub release configuration
+release:
+  github:
+    owner: diggsweden
+    overwrite: true # Allows updating existing releases
+    draft: false # Creates as final release, not draft
+    sign: true # Signs release assets
+    branch: main
+    changelog:
+      external: ReleasenotesTmp
+
+checksum:
+  algorithms:
+    - SHA-256
+    - SHA-512
+
+# GPG signing configuration
+signing:
+  active: ALWAYS
+  armored: true
+
+# SBOM generation
+catalog:
+  sbom:
+    syft:
+      active: ALWAYS
+      formats:
+        - CYCLONEDX_JSON
+        - SPDX_JSON
+      pack:
+        enabled: true
+
+# Syft need to know what to sign
+distributions:
+  library:
+    artifacts:
+      - path: target/{{projectName}}-{{projectVersion}}.jar

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
     <formatter-maven-plugin.version>2.26.0</formatter-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <checkstyle.version>10.25.0</checkstyle.version>
+
+    <jreleaser-maven-plugin.version>1.20.0</jreleaser-maven-plugin.version>
   </properties>
 
   <dependencies>
@@ -238,6 +240,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <!-- Release -->
+      <plugin>
+        <groupId>org.jreleaser</groupId>
+        <artifactId>jreleaser-maven-plugin</artifactId>
+        <version>${jreleaser-maven-plugin.version}</version>
+        <configuration>
+          <configFile>${project.basedir}/jreleaser.yml</configFile>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Add missing jreleaser conf for creating GH releasenotes and creating sboms for GH releases.

Fixes the https://github.com/diggsweden/wallet-client-gateway/actions/runs/17731138002 release part.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
