### PR TITLE
fix: markdown linting conflicting with changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           PACKAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # shellcheck disable=SC2086
-          mvn $MAVEN_CLI_OPTS package -DskipTests         
+          mvn $MAVEN_CLI_OPTS package -DskipTests
 
       - name: Import GPG key # Added this step
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0

--- a/development/megalinter.yml
+++ b/development/megalinter.yml
@@ -53,6 +53,7 @@ JAVA_CHECKSTYLE_CLI_EXECUTABLE:
 JAVA_CHECKSTYLE_FILTER_REGEX_INCLUDE: src/main
 JAVA_CHECKSTYLE_CONFIG_FILE: development/lint/google_checks.xml
 JAVA_PMD_CONFIG_FILE: development/sast/pmd_default_java.xml
+MARKDOWN_MARKDOWNLINT_ARGUMENTS: ["--disable", "MD024"]
 REPOSITORY_GITLEAKS_ARGUMENTS: detect --log-opts="main..HEAD"
 # LOG_LEVEL: DEBUG # will show you the exact command run
 PRE_COMMANDS:


### PR DESCRIPTION
Changeloggen som skapas bryter mot regel MD024. (Det får inte finnas flera headings med samma content i en markdownfil)

Att ignorera den regeln är en lösning på problemet.