### PR TITLE
feat: add swagger auth button and use relative url

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/config/OpenApiConfig.java
+++ b/src/main/java/se/digg/wallet/gateway/application/config/OpenApiConfig.java
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.gateway.application.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import jakarta.servlet.ServletContext;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI openApi(ServletContext servletContext) {
+    return new OpenAPI()
+        .info(new Info().title("Wallet Client Gateway").version("v1"))
+        .servers(List.of(new Server().url(servletContext.getContextPath())))
+        .components(new Components()
+            .addSecuritySchemes("ApiKeyScheme",
+                new SecurityScheme()
+                    .type(SecurityScheme.Type.APIKEY)
+                    .in(SecurityScheme.In.HEADER)
+                    .name(ApiKeyAuthFilter.API_KEY_HEADER)))
+        .addSecurityItem(new SecurityRequirement().addList("ApiKeyScheme"));
+  }
+
+}


### PR DESCRIPTION
# Pull Request Description

Adds OpenApi specs that does two things:
1. Adds an authorize button that sets X-API-KEY
2. Sets the server to be a relative server according to servlet path, instead of auto generating an absolute URL. Should work better behind https proxies.
