### PR TITLE
feat: add openapi-diff maven plugin

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -35,3 +35,6 @@ bca46c45ee653fc9216d1196b8e4f03a1219ce42:pom.xml:generic-api-key:331
 13abdfc364f48f41444a73c58ffcdfe310b1020e:README.md:generic-api-key:24
 13abdfc364f48f41444a73c58ffcdfe310b1020e:README.md:generic-api-key:48
 13abdfc364f48f41444a73c58ffcdfe310b1020e:README.md:generic-api-key:48
+056276748c8ba869bcdf38c484b0b1101f133560:openapi-linter.sh:generic-api-key:8
+056276748c8ba869bcdf38c484b0b1101f133560:README.md:generic-api-key:24
+056276748c8ba869bcdf38c484b0b1101f133560:README.md:generic-api-key:48

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ File output:
 
 A copy of the OpenAPI specification file will also appear in the target directory.
 
+### Ensure API backwards compatibility
+
+When making changes to the API-specification, backward compatibility is crucial and must be ensured.
+
+> **_Important!_**
+> If breaking the API backwards compatibility, a new major version of th API-specification must be implemented.
+
+This project utilizes the tool [openapi-diff](https://github.com/OpenAPITools/openapi-diff) configured as a
+maven plugin. On `mvn test` the API-specification in the project (newSpec) is compared with the current
+(oldSpec) preferably from production/sandbox. An error will be thrown if the backwards compatibility
+is broken.
+
+Configuration parameters with the openapi-diff-maven plugin in pom.xml:
+
+| Configuration parameter | Description                                                                               |
+|-------------------------|-------------------------------------------------------------------------------------------|
+| oldSpec                 | Path to the reference API-specification (production/sandbox).                             |
+| newSpec                 | Path to the project API-specification.                                                    |
+| failOnIncompatible      | true = fail only if API changes broke backward compatibility.                             |
+| failOnChanged           | true = fail if API changed but is backward compatible. Should preferably be set to false. |
+| consoleOutputFileName   | File path for console output.                                                             |
+| jsonOutputFileName      | File path for json output.                                                                |
+| markdownOutputFileName  | File path for markdown output.                                                            |
+
+Any detected changes will be presented in the configured output files.
+
 ## Contributing
 
 Please read our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) before submitting any contributions.

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <record-builder.version>51</record-builder.version>
     <openapi-generator-maven-plugin.version>7.21.0</openapi-generator-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <openapi-diff-maven.version>2.1.7</openapi-diff-maven.version>
   </properties>
 
   <dependencies>
@@ -374,6 +375,28 @@
               <sources>
                 <source>${project.basedir}/target/generated-sources/openapi/src/main/java</source>
               </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.openapitools.openapidiff</groupId>
+        <artifactId>openapi-diff-maven</artifactId>
+        <version>${openapi-diff-maven.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>diff</goal>
+            </goals>
+            <configuration>
+              <oldSpec>https://wallet.sandbox.digg.se/api/wallet-client-gateway-openapi-v0.yaml</oldSpec>
+              <newSpec>${project.basedir}/target/classes/static/wallet-client-gateway-openapi-v0.yaml</newSpec>
+              <failOnIncompatible>true</failOnIncompatible>
+              <failOnChanged>true</failOnChanged>
+              <consoleOutputFileName>${project.basedir}/target/openapi-diff.txt</consoleOutputFileName>
+              <jsonOutputFileName>${project.basedir}/target/openapi-diff.json</jsonOutputFileName>
+              <markdownOutputFileName>${project.basedir}/target/openapi-diff.md</markdownOutputFileName>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
# Pull Request Description

Add openapi-diff as a maven plugin to detect backwards compatibility issues with the API-specification.
Update README

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
