### PR TITLE
fix: exclude path with exact match

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/filter/LoggingFilter.java
+++ b/src/main/java/se/digg/wallet/gateway/application/filter/LoggingFilter.java
@@ -49,8 +49,8 @@ public class LoggingFilter extends OncePerRequestFilter {
   @Value("${properties.logging-filter.max-payload-length:10000}")
   private int maxPayloadLength;
 
-  @Value("${properties.logging-filter.exclude-path.starts-with:}")
-  private List<String> excludePathStartsWith;
+  @Value("${properties.logging-filter.exclude-path.exact-match:}")
+  private List<String> excludePathExactMatch;
 
   @Value("${properties.logging-filter.exclude-path.contains:}")
   private List<String> excludePathContains;
@@ -233,9 +233,10 @@ public class LoggingFilter extends OncePerRequestFilter {
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
+
     String path = request.getRequestURI();
 
-    return excludePathStartsWith.stream().anyMatch(path::startsWith)
+    return excludePathExactMatch.stream().anyMatch(path::equals)
         || excludePathContains.stream().anyMatch(path::contains);
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,10 +13,10 @@ properties:
     enabled: true
     max-payload-length: 100
     exclude-path:
-      starts-with: >
-        /actuator, /swagger, /v3/api-docs
+      exact-match: >
+        /
       contains: >
-        .html, .js, .yaml
+        /actuator, /swagger, /v3/api-docs, .html, .js, .yaml
     sensitive-data-mask:
       mask-value: "***MASKED***"
       # enter values in lower case

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,10 +41,10 @@ properties:
     enabled: true
     max-payload-length: 10000
     exclude-path:
-      starts-with: >
-        /actuator, /swagger, /v3/api-docs
+      exact-match: >
+        /, /wallet-client-gateway/, /api/
       contains: >
-        .html, .js, .yaml
+        /actuator, /swagger, /v3/api-docs, .html, .png, .gif, .js, .yaml
     sensitive-data-mask:
       mask-value: "***MASKED***"
       # enter values in lower case

--- a/src/test/java/se/digg/wallet/gateway/application/filter/LoggingFilterTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/filter/LoggingFilterTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(
     properties = {
         "properties.logging-filter.enabled=true",
-        "properties.logging-filter.exclude-path.starts-with=/actuator,/exclude",
+        "properties.logging-filter.exclude-path.exact-match=/,/exclude",
         "properties.logging-filter.exclude-path.contains=.html,.js,.yaml"
     })
 public class LoggingFilterTest {
@@ -98,11 +98,11 @@ public class LoggingFilterTest {
   }
 
   @Test
-  void shouldNotLogWhenPathStartsWithExcludePattern(CapturedOutput console)
+  void shouldNotLogWhenPathMatchExcludePattern(CapturedOutput console)
       throws IOException, ServletException {
 
     var httpServletRequest = MockMvcRequestBuilders
-        .get("/exclude")
+        .get("/")
         .buildRequest(new SpringBootMockServletContext("/"));
     var httpServletResponse = new MockHttpServletResponse();
 
@@ -119,7 +119,7 @@ public class LoggingFilterTest {
 
     var httpServletRequest = MockMvcRequestBuilders
         .get("/the-path/test.js")
-        .buildRequest(new SpringBootMockServletContext("/"));
+        .buildRequest(new SpringBootMockServletContext("/api"));
     var httpServletResponse = new MockHttpServletResponse();
 
     filter.doFilter(httpServletRequest, httpServletResponse, filterChain);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,10 +44,10 @@ properties:
     enabled: true
     max-payload-length: 100
     exclude-path:
-      starts-with: >
-        /actuator, /swagger, /api-docs
+      exact-match: >
+        /
       contains: >
-        .html, .js, .yaml
+        /actuator, /swagger, /api-docs, .html, .js, .yaml
     sensitive-data-mask:
       mask-value: "***MASKED***"
       # enter values in lower case


### PR DESCRIPTION
# Pull Request Description

Exclude path with exact match set in application properties.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
