### PR TITLE
fix: email and personal identity number are now optional

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/mapper/account/AccountMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/application/mapper/account/AccountMapper.java
@@ -18,7 +18,6 @@ import se.digg.wallet.gateway.domain.model.account.SecurityEnvelope;
 @Component
 public class AccountMapper {
 
-
   public CreateAccountResponseDto toResponse(Account account) {
     return CreateAccountResponseDto
         .builder()
@@ -29,7 +28,7 @@ public class AccountMapper {
   public NewAccount toDomain(CreateAccountRequestDto request) {
     return new NewAccount(
         request.getPersonalIdentityNumber().orElse(null),
-        request.getEmailAdress(),
+        request.getEmailAdress().orElse(null),
         request.getTelephoneNumber().orElse(null),
         toDomain(request.getPublicKey()));
   }
@@ -37,7 +36,7 @@ public class AccountMapper {
   public NewAccount toDomain(CreateAccountRequest request) {
     return new NewAccount(
         request.getPersonalIdentityNumber().orElse(null),
-        request.getEmailAdress(),
+        request.getEmailAdress().orElse(null),
         request.getTelephoneNumber().orElse(null),
         toDomain(request.getDeviceKey()));
   }

--- a/src/main/resources/external-apispec/wallet-account-openapi-v0.yaml
+++ b/src/main/resources/external-apispec/wallet-account-openapi-v0.yaml
@@ -294,8 +294,6 @@ components:
         deviceKey:
           $ref: '#/components/schemas/KeyRequest'
       required:
-        - personalIdentityNumber
-        - email
         - deviceKey
 
     AccountResponse:

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -541,7 +541,6 @@ components:
         publicKey:
           $ref: '#/components/schemas/KeyRequest'
       required:
-        - emailAdress
         - publicKey
 
     CreateAccountRequest:
@@ -560,7 +559,6 @@ components:
         deviceKey:
           $ref: '#/components/schemas/KeyRequest'
       required:
-        - emailAdress
         - deviceKey
 
     KeyRequest:

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerIntegrationTest.java
@@ -12,9 +12,8 @@ import static se.digg.wallet.gateway.application.model.CreateAccountRequestDtoTe
 import static se.digg.wallet.gateway.application.model.CreateAccountRequestDtoTestBuilder.TELEPHONE_NUMBER;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-
+import java.util.Map;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,11 +23,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.wiremock.spring.InjectWireMock;
+
+import se.digg.wallet.gateway.api.v0.model.CreateAccountRequest;
 import se.digg.wallet.gateway.application.config.ApplicationConfig;
 import se.digg.wallet.gateway.application.config.SecurityConfig;
 import se.digg.wallet.gateway.application.controller.util.WalletAccountMock;
 import se.digg.wallet.gateway.application.model.CreateAccountRequestDtoTestBuilder;
 import se.digg.wallet.gateway.application.model.CreateAccountRequestTestBuilder;
+import se.digg.wallet.gateway.application.model.KeyRequestTestBuilder;
 import se.digg.wallet.gateway.client.account.origin.model.AccountDto;
 import se.digg.wallet.gateway.client.account.origin.model.CreateAccountRequestDto;
 import se.digg.wallet.gateway.client.account.origin.model.PublicKeyDto;
@@ -89,6 +91,21 @@ class AccountControllerIntegrationTest {
   }
 
   @Test
+  void testCreateAccountWithEmptyEmailAndSsn() throws Exception {
+    var generatedAccountId = stubAccountCreationWithNullValues();
+    var accountWithEmptyEmailAndSsn = CreateAccountRequest.builder()
+        .deviceKey(KeyRequestTestBuilder.withDefaults().build())
+        .build();
+    var response = restClient.post()
+        .uri("/v0/accounts")
+        .header(SecurityConfig.API_KEY_HEADER, applicationConfig.apisecret())
+        .body(accountWithEmptyEmailAndSsn)
+        .exchange();
+
+    expectCreatedWithAccountId(response, generatedAccountId);
+  }
+
+  @Test
   void testAccountReturns500IfAccountServiceRespondsWith404() {
     server.stubFor(post("/account")
         .willReturn(aResponse()
@@ -107,7 +124,7 @@ class AccountControllerIntegrationTest {
   @Test
   void testValidation() {
     var requestBody = CreateAccountRequestDtoTestBuilder.withDefaults()
-        .emailAdress(null)
+        .publicKey(null)
         .build();
     var response = restClient.post()
         .uri("accounts")
@@ -117,6 +134,37 @@ class AccountControllerIntegrationTest {
 
     response.expectStatus()
         .isEqualTo(400);
+  }
+
+  private UUID stubAccountCreationWithNullValues() throws Exception {
+    var generatedAccountId = UUID.randomUUID();
+
+    var expectedRequest = Map.of("deviceKey", Map.of(
+        "kty", "KTY",
+        "kid", "KID",
+        "alg", "ALG",
+        "use", "USE",
+        "crv", "CRV",
+        "x", "X",
+        "y", "Y"));
+
+    var expectedResponse = AccountResponse.builder()
+        .id(generatedAccountId)
+        .email(null)
+        .phoneNumber(null)
+        .deviceKey(KeyResponse.builder()
+            .kty("KTY").kid("KID").alg("ALG").use("USE")
+            .crv("CRV").x("X").y("Y").build())
+        .build();
+
+    server.stubFor(post("/v0/accounts")
+        .withRequestBody(equalToJson(objectMapper.writeValueAsString(expectedRequest), true, true))
+        .willReturn(aResponse()
+            .withStatus(201)
+            .withHeader("content-type", "application/json")
+            .withBody(objectMapper.writeValueAsString(expectedResponse))));
+
+    return generatedAccountId;
   }
 
   private UUID stubAccountCreation() throws Exception {


### PR DESCRIPTION
# Pull Request Description

Email and personal identity number are now optional when creating a wallet account.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
