### PR TITLE
feat: forward stateJws from R2PS async operation response

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/controller/DefaultExceptionHandler.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/DefaultExceptionHandler.java
@@ -23,6 +23,7 @@ import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -268,7 +269,9 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
   private ResponseEntity<Object> createResponseEntity(ProblemResponse problemResponse) {
 
     problemResponse.setTransactionId(Optional.of(MDC.get(MDC_TRANSACTION_ID)));
-    return ResponseEntity.status(problemResponse.getStatus()).body(problemResponse);
+    return ResponseEntity.status(problemResponse.getStatus())
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(problemResponse);
   }
 
   private ProblemResponse.Builder buildProblemResponse(ProblemType problemType) {

--- a/src/main/java/se/digg/wallet/gateway/application/mapper/hsm/HsmMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/application/mapper/hsm/HsmMapper.java
@@ -32,7 +32,7 @@ public class HsmMapper {
         deviceKeyRequest.getX(),
         deviceKeyRequest.getY(),
         deviceKeyRequest.getKid());
-    return new DeviceStateRegistration(publicKey, request.getOverwrite(), request.getTtl());
+    return new DeviceStateRegistration(publicKey, request.getTtl());
   }
 
   public HsmOperation toDomain(HsmRequest request) {
@@ -46,6 +46,7 @@ public class HsmMapper {
         .status(toHsmRequestStatus(result.status()))
         .result(result.result())
         .resultUrl(toGatewayResultUrl(result))
+        .stateJws(result.stateJws())
         .build();
   }
 

--- a/src/main/java/se/digg/wallet/gateway/domain/model/hsm/DeviceStateRegistration.java
+++ b/src/main/java/se/digg/wallet/gateway/domain/model/hsm/DeviceStateRegistration.java
@@ -8,6 +8,5 @@ import java.util.Optional;
 
 public record DeviceStateRegistration(
     EcPublicJwk walletKey,
-    boolean overwrite,
     Optional<String> ttl) {
 }

--- a/src/main/java/se/digg/wallet/gateway/infrastructure/hsm/mapper/HsmClientMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/infrastructure/hsm/mapper/HsmClientMapper.java
@@ -27,7 +27,7 @@ public class HsmClientMapper {
         publicKey.x(),
         publicKey.y(),
         publicKey.kid());
-    return new R2PSDeviceStateRequestDto(clientPublicKey, request.overwrite(), request.ttl());
+    return new R2PSDeviceStateRequestDto(clientPublicKey, false, request.ttl());
   }
 
   public R2PSOperationRequestDto toClientRequest(HsmOperation request) {

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -347,7 +347,7 @@ paths:
               $ref: '#/components/schemas/RegisterStateRequest'
         required: true
       responses:
-        '200':
+        '201':
           description: The registered state.
           content:
             application/json:
@@ -685,25 +685,17 @@ components:
     RegisterStateRequest:
       type: object
       properties:
-        clientId:
-          type: string
-          description: The unique client identification
         deviceKey:
           allOf:
             - $ref: '#/components/schemas/KeyRequest'
           description: Device public key
-        overwrite:
-          type: boolean
-          description: Whether to overwrite an existing state
         ttl:
           type: string
           description: Optional. Time-to-live for the state. Use ISO 8601 duration format.
           pattern: '^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$'
           example: P30D
       required:
-        - clientId
         - deviceKey
-        - overwrite
 
     RegisterStateResponse:
       type: object

--- a/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
@@ -115,7 +115,6 @@ class HsmControllerIntegrationTest {
                 .y("y")
                 .kid("kid")
                 .build())
-            .overwrite(false)
             .ttl(ISO_8601_DURATION_30_DAYS)
             .build())
         .exchange()
@@ -146,7 +145,6 @@ class HsmControllerIntegrationTest {
                 """.formatted(clientId, TEST_DEV_AUTH_CODE))));
 
     var registerStateRequest = se.digg.wallet.gateway.api.v0.model.RegisterStateRequest.builder()
-        .clientId(clientId)
         .deviceKey(se.digg.wallet.gateway.api.v0.model.KeyRequest.builder()
             .kty("EC")
             .crv("P-256")
@@ -154,7 +152,6 @@ class HsmControllerIntegrationTest {
             .y("y")
             .kid("kid")
             .build())
-        .overwrite(false)
         .ttl(ISO_8601_DURATION_30_DAYS)
         .build();
 
@@ -224,7 +221,6 @@ class HsmControllerIntegrationTest {
                 """)));
 
     var registerStateRequest = se.digg.wallet.gateway.api.v0.model.RegisterStateRequest.builder()
-        .clientId(clientId)
         .deviceKey(se.digg.wallet.gateway.api.v0.model.KeyRequest.builder()
             .kty("EC")
             .crv("P-256")
@@ -232,7 +228,6 @@ class HsmControllerIntegrationTest {
             .y("y")
             .kid("kid")
             .build())
-        .overwrite(false)
         .ttl(ISO_8601_DURATION_30_DAYS)
         .build();
 
@@ -258,7 +253,6 @@ class HsmControllerIntegrationTest {
   void validationFailureWithBadTtlFormat(String ttl) {
 
     var registerStateRequest = se.digg.wallet.gateway.api.v0.model.RegisterStateRequest.builder()
-        .clientId(clientId)
         .deviceKey(se.digg.wallet.gateway.api.v0.model.KeyRequest.builder()
             .kty("EC")
             .crv("P-256")
@@ -266,7 +260,6 @@ class HsmControllerIntegrationTest {
             .y("y")
             .kid("kid")
             .build())
-        .overwrite(false)
         .ttl(ttl)
         .build();
 
@@ -302,9 +295,10 @@ class HsmControllerIntegrationTest {
                   "opaqueServerId": "another-string",
                   "status": "complete",
                   "result": "%s",
-                  "resultUrl": null
+                  "resultUrl": null,
+                  "stateJws": "%s"
                 }
-                """.formatted(requestId, TEST_JWT))));
+                """.formatted(requestId, TEST_JWT, TEST_JWT))));
 
     restClient.post()
         .uri(HSM_REQUESTS_URL)
@@ -322,9 +316,10 @@ class HsmControllerIntegrationTest {
               "status": "COMPLETE",
               "id": "%s",
               "result": "%s",
-              "resultUrl": null
+              "resultUrl": null,
+              "stateJws": "%s"
             }
-            """.formatted(requestId, TEST_JWT));
+            """.formatted(requestId, TEST_JWT, TEST_JWT));
   }
 
   @Test


### PR DESCRIPTION
* feat: map stateJws from AsyncHsmOperationResult onto HsmResponse
* chore: remove overwrite and clientId fields from RegisterStateRequest
* chore: set application/problem+json content type on error responses
* chore: update register-state response code to 201 in OpenAPI spec
* test: assert stateJws is present in complete HSM operation response

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
