### PR TITLE
feat: store HSM clientId and stateJws on the account

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/controller/AccountController.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/AccountController.java
@@ -13,14 +13,12 @@ import se.digg.wallet.gateway.api.v0.AccountApi;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountRequest;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountResponse;
 import se.digg.wallet.gateway.api.v0.model.EcJwkRequest;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopeRequest;
 import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopesResponse;
 import se.digg.wallet.gateway.application.auth.CurrentAccount;
 import se.digg.wallet.gateway.application.mapper.account.AccountMapper;
 import se.digg.wallet.gateway.domain.model.account.Account;
 import se.digg.wallet.gateway.domain.model.account.Jwk;
 import se.digg.wallet.gateway.domain.model.account.NewAccount;
-import se.digg.wallet.gateway.domain.model.account.SecurityEnvelope;
 import se.digg.wallet.gateway.domain.model.account.SecurityEnvelopes;
 import se.digg.wallet.gateway.domain.service.account.AccountService;
 
@@ -55,19 +53,6 @@ public class AccountController implements AccountApi {
     var accountId = currentAccount.id();
     SecurityEnvelopes envelopes = accountService.getSecurityEnvelopes(accountId);
     return ResponseEntity.ok(mapper.toResponse(envelopes));
-  }
-
-  @Override
-  public ResponseEntity<Void> addAccountSecurityEnvelope(
-      @Valid SecurityEnvelopeRequest securityEnvelopeRequest) {
-    var accountId = currentAccount.id();
-    SecurityEnvelope envelope = mapper.toDomain(securityEnvelopeRequest);
-    accountService.addAccountSecurityEnvelope(envelope, accountId);
-
-    return ResponseEntity
-        .status(HttpStatus.CREATED)
-        .build();
-
   }
 
   @Override

--- a/src/main/java/se/digg/wallet/gateway/application/controller/AccountController.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/AccountController.java
@@ -13,13 +13,11 @@ import se.digg.wallet.gateway.api.v0.AccountApi;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountRequest;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountResponse;
 import se.digg.wallet.gateway.api.v0.model.EcJwkRequest;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopesResponse;
 import se.digg.wallet.gateway.application.auth.CurrentAccount;
 import se.digg.wallet.gateway.application.mapper.account.AccountMapper;
 import se.digg.wallet.gateway.domain.model.account.Account;
 import se.digg.wallet.gateway.domain.model.account.Jwk;
 import se.digg.wallet.gateway.domain.model.account.NewAccount;
-import se.digg.wallet.gateway.domain.model.account.SecurityEnvelopes;
 import se.digg.wallet.gateway.domain.service.account.AccountService;
 
 @RestController
@@ -46,13 +44,6 @@ public class AccountController implements AccountApi {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(createAccountResponse);
-  }
-
-  @Override
-  public ResponseEntity<SecurityEnvelopesResponse> getAccountSecurityEnvelopes() {
-    var accountId = currentAccount.id();
-    SecurityEnvelopes envelopes = accountService.getSecurityEnvelopes(accountId);
-    return ResponseEntity.ok(mapper.toResponse(envelopes));
   }
 
   @Override

--- a/src/main/java/se/digg/wallet/gateway/application/controller/HsmController.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/HsmController.java
@@ -15,6 +15,7 @@ import se.digg.wallet.gateway.api.v0.model.HsmRequestType;
 import se.digg.wallet.gateway.api.v0.model.HsmResponse;
 import se.digg.wallet.gateway.api.v0.model.RegisterStateRequest;
 import se.digg.wallet.gateway.api.v0.model.RegisterStateResponse;
+import se.digg.wallet.gateway.application.auth.CurrentAccount;
 import se.digg.wallet.gateway.application.mapper.hsm.HsmMapper;
 import se.digg.wallet.gateway.domain.service.hsm.HsmService;
 
@@ -23,17 +24,19 @@ public class HsmController implements HsmApi {
 
   private final HsmService hsmService;
   private final HsmMapper mapper;
+  private final CurrentAccount currentAccount;
 
-  HsmController(HsmService hsmService, HsmMapper mapper) {
+  HsmController(HsmService hsmService, HsmMapper mapper, CurrentAccount currentAccount) {
     this.hsmService = hsmService;
     this.mapper = mapper;
+    this.currentAccount = currentAccount;
   }
 
   @Override
   public ResponseEntity<HsmResponse> createRequest(HsmRequest hsmRequest,
       Optional<HsmRequestType> type) {
 
-    var result = hsmService.submitAsync(mapper.toDomain(hsmRequest));
+    var result = hsmService.submitAsync(mapper.toDomain(hsmRequest), currentAccount.id());
     var hsmResponse = mapper.toHsmResponse(result);
 
     return switch (hsmResponse.getStatus()) {
@@ -46,7 +49,7 @@ public class HsmController implements HsmApi {
   @Override
   public ResponseEntity<HsmResponse> getResult(UUID id) {
 
-    var result = hsmService.getAsyncResult(id);
+    var result = hsmService.getAsyncResult(id, currentAccount.id());
     var hsmResponse = mapper.toHsmResponse(result);
 
     return switch (hsmResponse.getStatus()) {
@@ -60,7 +63,8 @@ public class HsmController implements HsmApi {
   public ResponseEntity<RegisterStateResponse> saveState(
       RegisterStateRequest registerStateRequest) {
 
-    var result = hsmService.registerState(mapper.toDomain(registerStateRequest));
+    var result =
+        hsmService.registerState(mapper.toDomain(registerStateRequest), currentAccount.id());
 
     return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toRegisterStateResponse(result));
   }

--- a/src/main/java/se/digg/wallet/gateway/application/mapper/account/AccountMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/application/mapper/account/AccountMapper.java
@@ -10,13 +10,11 @@ import org.springframework.stereotype.Component;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountRequest;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountResponse;
 import se.digg.wallet.gateway.api.v0.model.EcJwkRequest;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopeRequest;
 import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopeResponse;
 import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopesResponse;
 import se.digg.wallet.gateway.domain.model.account.Account;
 import se.digg.wallet.gateway.domain.model.account.Jwk;
 import se.digg.wallet.gateway.domain.model.account.NewAccount;
-import se.digg.wallet.gateway.domain.model.account.SecurityEnvelope;
 import se.digg.wallet.gateway.domain.model.account.SecurityEnvelopes;
 
 @Component
@@ -53,9 +51,5 @@ public class AccountMapper {
         request.getCrv(),
         request.getX(),
         request.getY());
-  }
-
-  public SecurityEnvelope toDomain(SecurityEnvelopeRequest request) {
-    return new SecurityEnvelope(request.getContent());
   }
 }

--- a/src/main/java/se/digg/wallet/gateway/application/mapper/account/AccountMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/application/mapper/account/AccountMapper.java
@@ -3,19 +3,14 @@
 // SPDX-License-Identifier: EUPL-1.2
 package se.digg.wallet.gateway.application.mapper.account;
 
-import java.util.List;
-
 import org.springframework.stereotype.Component;
 
 import se.digg.wallet.gateway.api.v0.model.CreateAccountRequest;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountResponse;
 import se.digg.wallet.gateway.api.v0.model.EcJwkRequest;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopeResponse;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopesResponse;
 import se.digg.wallet.gateway.domain.model.account.Account;
 import se.digg.wallet.gateway.domain.model.account.Jwk;
 import se.digg.wallet.gateway.domain.model.account.NewAccount;
-import se.digg.wallet.gateway.domain.model.account.SecurityEnvelopes;
 
 @Component
 public class AccountMapper {
@@ -25,13 +20,6 @@ public class AccountMapper {
         .builder()
         .accountId(account.id())
         .build();
-  }
-
-  public SecurityEnvelopesResponse toResponse(SecurityEnvelopes envelopes) {
-    List<SecurityEnvelopeResponse> items = envelopes.items().stream()
-        .map(e -> SecurityEnvelopeResponse.builder().content(e.content()).build())
-        .toList();
-    return SecurityEnvelopesResponse.builder().items(items).build();
   }
 
   public NewAccount toDomain(CreateAccountRequest request) {

--- a/src/main/java/se/digg/wallet/gateway/application/mapper/hsm/HsmMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/application/mapper/hsm/HsmMapper.java
@@ -44,8 +44,6 @@ public class HsmMapper {
   public HsmOperation toDomain(HsmRequest request) {
     return HsmOperationBuilder.builder()
         .outerRequestJws(request.getOuterRequestJws())
-        .clientId(request.getClientId())
-        .stateJws(request.getStateJws().orElse(null))
         .build();
   }
 

--- a/src/main/java/se/digg/wallet/gateway/application/mapper/hsm/HsmMapper.java
+++ b/src/main/java/se/digg/wallet/gateway/application/mapper/hsm/HsmMapper.java
@@ -53,7 +53,6 @@ public class HsmMapper {
         .status(HsmAsyncStatus.fromValue(result.status().name()))
         .result(result.result())
         .resultUrl(toGatewayResultUrl(result))
-        .stateJws(result.stateJws())
         .build();
   }
 
@@ -70,12 +69,10 @@ public class HsmMapper {
         .build();
 
     return RegisterStateResponse.builder()
-        .clientId(result.clientId())
         .serverJwsPublicKey(serverJwsPublicKeyResponse)
         .status(result.status())
         .opaqueServerId(result.opaqueServerId())
         .devAuthorizationCode(result.devAuthorizationCode())
-        .stateJws(result.stateJws())
         .build();
   }
 

--- a/src/main/java/se/digg/wallet/gateway/domain/ports/outbound/AccountPort.java
+++ b/src/main/java/se/digg/wallet/gateway/domain/ports/outbound/AccountPort.java
@@ -23,4 +23,8 @@ public interface AccountPort {
   SecurityEnvelopes getSecurityEnvelopes(String accountId);
 
   Jwk getWalletKey(String accountId);
+
+  String getHsmClientId(String accountId);
+
+  void saveHsmClientId(String clientId, String accountId);
 }

--- a/src/main/java/se/digg/wallet/gateway/domain/service/account/AccountService.java
+++ b/src/main/java/se/digg/wallet/gateway/domain/service/account/AccountService.java
@@ -42,4 +42,12 @@ public class AccountService {
     return accountPort.getSecurityEnvelopes(accountId);
   }
 
+  public String getHsmClientId(String accountId) {
+    return accountPort.getHsmClientId(accountId);
+  }
+
+  public void saveHsmClientId(String clientId, String accountId) {
+    accountPort.saveHsmClientId(clientId, accountId);
+  }
+
 }

--- a/src/main/java/se/digg/wallet/gateway/domain/service/hsm/HsmService.java
+++ b/src/main/java/se/digg/wallet/gateway/domain/service/hsm/HsmService.java
@@ -6,30 +6,71 @@ package se.digg.wallet.gateway.domain.service.hsm;
 
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import se.digg.wallet.gateway.domain.model.account.SecurityEnvelope;
+import se.digg.wallet.gateway.domain.model.account.SecurityEnvelopes;
 import se.digg.wallet.gateway.domain.model.hsm.DeviceStateRegistration;
 import se.digg.wallet.gateway.domain.model.hsm.DeviceStateRegistrationResult;
 import se.digg.wallet.gateway.domain.model.hsm.HsmOperation;
+import se.digg.wallet.gateway.domain.model.hsm.HsmOperationBuilder;
 import se.digg.wallet.gateway.domain.model.hsm.HsmOperationResult;
 import se.digg.wallet.gateway.domain.ports.outbound.HsmPort;
+import se.digg.wallet.gateway.domain.service.account.AccountService;
 
 @Service
 public class HsmService {
 
   private final HsmPort hsmPort;
+  private final AccountService accountService;
 
-  HsmService(HsmPort hsmPort) {
+  HsmService(HsmPort hsmPort, AccountService accountService) {
     this.hsmPort = hsmPort;
+    this.accountService = accountService;
   }
 
-  public DeviceStateRegistrationResult registerState(DeviceStateRegistration request) {
-    return hsmPort.registerState(request);
+  public DeviceStateRegistrationResult registerState(DeviceStateRegistration request,
+      String accountId) {
+    DeviceStateRegistrationResult result = hsmPort.registerState(request);
+
+    if (result.clientId() != null) {
+      accountService.saveHsmClientId(result.clientId(), accountId);
+    }
+
+    persistStateJws(result.stateJws(), accountId);
+    return result;
   }
 
-  public HsmOperationResult submitAsync(HsmOperation request) {
-    return hsmPort.submitAsync(request);
+  public HsmOperationResult submitAsync(HsmOperation request, String accountId) {
+    HsmOperationResult result = hsmPort.submitAsync(withAccountState(request, accountId));
+    persistStateJws(result.stateJws(), accountId);
+    return result;
   }
 
-  public HsmOperationResult getAsyncResult(UUID id) {
-    return hsmPort.getAsyncResult(id);
+  public HsmOperationResult getAsyncResult(UUID id, String accountId) {
+    HsmOperationResult result = hsmPort.getAsyncResult(id);
+    persistStateJws(result.stateJws(), accountId);
+    return result;
+  }
+
+  private HsmOperation withAccountState(HsmOperation request, String accountId) {
+    return HsmOperationBuilder.builder()
+        .outerRequestJws(request.outerRequestJws())
+        .clientId(accountService.getHsmClientId(accountId))
+        .stateJws(currentStateJws(accountId))
+        .build();
+  }
+
+  private String currentStateJws(String accountId) {
+    SecurityEnvelopes envelopes = accountService.getSecurityEnvelopes(accountId);
+    if (envelopes == null || envelopes.items() == null || envelopes.items().isEmpty()) {
+      return null;
+    }
+    return envelopes.items().getFirst().content();
+  }
+
+  private void persistStateJws(String stateJws, String accountId) {
+    if (stateJws == null) {
+      return;
+    }
+    accountService.addAccountSecurityEnvelope(new SecurityEnvelope(stateJws), accountId);
   }
 }

--- a/src/main/java/se/digg/wallet/gateway/domain/service/hsm/HsmService.java
+++ b/src/main/java/se/digg/wallet/gateway/domain/service/hsm/HsmService.java
@@ -52,8 +52,7 @@ public class HsmService {
   }
 
   private HsmOperation withAccountState(HsmOperation request, String accountId) {
-    return HsmOperationBuilder.builder()
-        .outerRequestJws(request.outerRequestJws())
+    return HsmOperationBuilder.builder(request)
         .clientId(accountService.getHsmClientId(accountId))
         .stateJws(currentStateJws(accountId))
         .build();

--- a/src/main/java/se/digg/wallet/gateway/infrastructure/account/client/WalletAccountAdapter.java
+++ b/src/main/java/se/digg/wallet/gateway/infrastructure/account/client/WalletAccountAdapter.java
@@ -12,6 +12,7 @@ import se.digg.wallet.gateway.client.account.origin.api.AccountControllerApi;
 import se.digg.wallet.gateway.client.account.origin.model.AccountDto;
 import se.digg.wallet.gateway.client.account.v0.api.AccountApi;
 import se.digg.wallet.gateway.client.account.v0.model.AccountResponse;
+import se.digg.wallet.gateway.client.account.v0.model.HsmClientIdRequest;
 import se.digg.wallet.gateway.client.account.v0.model.KeyRequest;
 import se.digg.wallet.gateway.client.account.v0.model.SecurityEnvelopeRequest;
 import se.digg.wallet.gateway.domain.model.account.Account;
@@ -76,6 +77,19 @@ public class WalletAccountAdapter implements AccountPort {
   public Jwk getWalletKey(String accountId) {
     UUID id = UUID.fromString(accountId);
     return accountClientMapper.toDomainJwk(accountApi.getAccountWalletKey(id, null));
+  }
+
+  @Override
+  public String getHsmClientId(String accountId) {
+    UUID id = UUID.fromString(accountId);
+    return accountApi.getAccountHsmClientId(id).getClientId();
+  }
+
+  @Override
+  public void saveHsmClientId(String clientId, String accountId) {
+    UUID id = UUID.fromString(accountId);
+    HsmClientIdRequest request = HsmClientIdRequest.builder().clientId(clientId).build();
+    accountApi.addAccountHsmClientId(id, request);
   }
 
 }

--- a/src/main/resources/external-apispec/wallet-account-openapi-v0.yaml
+++ b/src/main/resources/external-apispec/wallet-account-openapi-v0.yaml
@@ -196,6 +196,51 @@ paths:
         'default':
           $ref: '#/components/responses/default'
 
+  /v0/accounts/{id}/hsm-client-id:
+    post:
+      tags:
+        - Account
+      summary: Set the HSM client id for an account
+      description: Stores the HSM client identifier for the account.
+      operationId: addAccountHsmClientId
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HsmClientIdRequest'
+        required: true
+      responses:
+        '201':
+          description: HSM client id stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HsmClientIdResponse'
+        'default':
+          $ref: '#/components/responses/default'
+
+    get:
+      tags:
+        - Account
+      summary: Get the HSM client id for an account
+      description: Get the HSM client identifier stored for a given account.
+      operationId: getAccountHsmClientId
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      responses:
+        '200':
+          description: The HSM client id being returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HsmClientIdResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        'default':
+          $ref: '#/components/responses/default'
+
 components:
   parameters:
     AccountId:
@@ -227,22 +272,61 @@ components:
   schemas:
     ProblemResponse:
       type: object
-      description: This is a common standard object returned on request failure with any operation.
+      description: Problem detail object based on RFC 9457, returned on request failure with any operation.
       properties:
         type:
           type: string
-        title:
-          type: string
+          description: |
+            A URI that identifies the problem type. When this member is null, blank or not present,
+            its value is assumed to be "about:blank". It indicates that the problem has no additional
+            semantics beyond that of the HTTP status code.
+          example: /problem-details/field-validation-failure
         status:
           type: integer
           description: Reflects the http response status code with 3 digits returned by the server.
           minLength: 3
           maxLength: 3
           example: 400
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+          example: Field validation failure
         detail:
           type: string
+          description: A human-readable explanation specific to this occurrence of the problem.
+          example: Request body field value(s) does not validate.
         instance:
           type: string
+          description: |
+            A URI reference that identifies the specific occurrence of the problem.
+            Typically the relative path of the request.
+          example: /v0/accounts
+        transaction-id:
+          type: string
+          description: A unique request identifier to be used for debug or troubleshooting.
+        invalid-parameters:
+          type: array
+          description: |
+            A list of invalid request (header, query or body) parameters. Depending on the problem type,
+            this property might be null, empty or not present.
+          items:
+            $ref: "#/components/schemas/ProblemParameterResponse"
+
+    ProblemParameterResponse:
+      type: object
+      description: Detailed information about an invalid request parameter.
+      properties:
+        reason:
+          type: string
+          description: A human readable explanation specific to the parameter.
+          example: must not be null
+        value:
+          type: string
+          description: The requested parameter value.
+        property:
+          type: string
+          description: Name of the property.
+          example: deviceKey
 
     ApiInfoResponse:
       type: object
@@ -400,3 +484,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SecurityEnvelopeResponse'
+
+    HsmClientIdRequest:
+      type: object
+      properties:
+        clientId:
+          type: string
+          minLength: 1
+          description: HSM client identifier, minted at device-state registration.
+          example: 'b9f6edba-b69d-4e56-be22-dae25a45ff91'
+      required:
+        - clientId
+
+    HsmClientIdResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/HsmClientIdRequest'

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -549,9 +549,6 @@ components:
         resultUrl:
           type: string
           description: Gateway URL where the asynchronous operation result can be polled.
-        stateJws:
-          type: string
-          description: Updated device-state token. Present when status=complete. Persist and send as stateJws on the next request.
       required:
         - id
         - status
@@ -574,20 +571,14 @@ components:
       properties:
         status:
           type: string
-        clientId:
-          type: string
         devAuthorizationCode:
           type: string
         serverJwsPublicKey:
           $ref: '#/components/schemas/EcJwkResponse'
         opaqueServerId:
           type: string
-        stateJws:
-          type: string
-          description: JWS-encoded device state. Store alongside clientId and send as stateJws on subsequent requests.
       required:
         - status
-        - clientId
 
     AuthChallengeDto:
       type: object

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -597,16 +597,8 @@ components:
           type: string
           minLength: 1
           description: Outer request JWS payload for the HSM operation.
-        clientId:
-          type: string
-          minLength: 1
-          description: Client identifier
-        stateJws:
-          type: string
-          description: Optional. Encoded device-state token. When present the BFF skips the Valkey lookup.
       required:
         - outerRequestJws
-        - clientId
 
     HsmAsyncStatus:
       type: string

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -123,27 +123,6 @@ paths:
         'default':
           $ref: '#/components/responses/default'
 
-    post:
-      tags:
-        - Account
-      summary: Add a security envelope to an account
-      description: |
-        This operation will add a security envelope (typically used with the HSM) to the associated account.
-        An account can only have one security envelope for each type. Any existing envelope with the requested
-        type will be replaced.
-      operationId: addAccountSecurityEnvelope
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecurityEnvelopeRequest'
-        required: true
-      responses:
-        '201':
-          description: The security envelope has been added to the account
-        'default':
-          $ref: '#/components/responses/default'
-
   /public/auth/session/challenge:
     get:
       tags:
@@ -539,25 +518,6 @@ components:
     EcJwkResponse:
       allOf:
         - $ref: '#/components/schemas/EcJwkRequest'
-
-    SecurityEnvelopeType:
-      type: string
-      description: 'Security envelope type enum constants.'
-      enum:
-        - SIGN
-        - OTHER
-
-    SecurityEnvelopeRequest:
-      properties:
-        type:
-          $ref: '#/components/schemas/SecurityEnvelopeType'
-        content:
-          type: string
-          description: The security envelope content. Typically encrypted opaque materials.
-          minLength: 1
-      required:
-        - type
-        - content
 
     SecurityEnvelopeResponse:
       type: object

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -104,25 +104,6 @@ paths:
         'default':
           $ref: '#/components/responses/default'
 
-  /v0/accounts/security-envelopes:
-    get:
-      tags:
-        - Account
-      summary: Get security envelopes
-      description: Returns the security envelopes associated with the authenticated account.
-      operationId: getAccountSecurityEnvelopes
-      responses:
-        '200':
-          description: Security envelopes retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SecurityEnvelopesResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        'default':
-          $ref: '#/components/responses/default'
-
   /public/auth/session/challenge:
     get:
       tags:
@@ -518,24 +499,6 @@ components:
     EcJwkResponse:
       allOf:
         - $ref: '#/components/schemas/EcJwkRequest'
-
-    SecurityEnvelopeResponse:
-      type: object
-      properties:
-        content:
-          type: string
-          description: The security envelope content. Typically encrypted opaque materials.
-          minLength: 1
-      required:
-        - content
-
-    SecurityEnvelopesResponse:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/SecurityEnvelopeResponse'
 
     HsmRequestType:
       type: string

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerAuthenticatedIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerAuthenticatedIntegrationTest.java
@@ -6,9 +6,7 @@ package se.digg.wallet.gateway.application.controller;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.nimbusds.jose.jwk.ECKey;

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerAuthenticatedIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerAuthenticatedIntegrationTest.java
@@ -28,8 +28,6 @@ import org.springframework.test.web.servlet.client.RestTestClient;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.wiremock.spring.InjectWireMock;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopeRequest;
-import se.digg.wallet.gateway.api.v0.model.SecurityEnvelopeType;
 import se.digg.wallet.gateway.client.account.v0.model.SecurityEnvelopeResponse;
 import se.digg.wallet.gateway.client.account.v0.model.SecurityEnvelopesResponse;
 import se.digg.wallet.gateway.application.config.ApplicationConfig;
@@ -151,34 +149,6 @@ class AccountControllerAuthenticatedIntegrationTest {
   }
 
   @Test
-  void testAddSecurityEnvelope() throws Exception {
-    var envelopeContent = "envelope-content";
-
-    var expectedDownstreamRequest =
-        se.digg.wallet.gateway.client.account.v0.model.SecurityEnvelopeRequest.builder()
-            .content(envelopeContent)
-            .build();
-
-    accountServer.stubFor(post("/v0/accounts/" + ACCOUNT_ID + "/security-envelopes")
-        .withRequestBody(equalToJson(objectMapper.writeValueAsString(expectedDownstreamRequest)))
-        .willReturn(aResponse()
-            .withStatus(201)
-            .withHeader("content-type", "application/json")
-            .withBody("{}")));
-
-    var response = restClient.post()
-        .uri("/v0/accounts/security-envelopes")
-        .header(SecurityConfig.API_KEY_HEADER, applicationConfig.apisecret())
-        .body(SecurityEnvelopeRequest.builder()
-            .type(SecurityEnvelopeType.SIGN)
-            .content(envelopeContent)
-            .build())
-        .exchange();
-
-    response.expectStatus().isCreated();
-  }
-
-  @Test
   void testGetSecurityEnvelopes() throws Exception {
     var envelopeContent = "opaque-envelope-content";
 
@@ -218,27 +188,4 @@ class AccountControllerAuthenticatedIntegrationTest {
     response.expectStatus().isEqualTo(500);
   }
 
-  @Test
-  void returnsProblemWithStatus500WhenSaveSecurityEnvelopeDownstreamFails() {
-    accountServer.stubFor(post("/v0/accounts/" + ACCOUNT_ID + "/security-envelopes")
-        .willReturn(aResponse().withStatus(400)));
-
-    var response = restClient.post()
-        .uri("/v0/accounts/security-envelopes")
-        .header(SecurityConfig.API_KEY_HEADER, applicationConfig.apisecret())
-        .body(SecurityEnvelopeRequest.builder()
-            .type(SecurityEnvelopeType.SIGN)
-            .content("content")
-            .build())
-        .exchange();
-
-    var expectedStatus = 500;
-    response.expectStatus().isEqualTo(expectedStatus)
-        .expectBody()
-        .jsonPath("$.status").isEqualTo(expectedStatus)
-        .jsonPath("$.type").exists()
-        .jsonPath("$.title").exists()
-        .jsonPath("$.detail").exists()
-        .jsonPath("$.instance").exists();
-  }
 }

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerAuthenticatedIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerAuthenticatedIntegrationTest.java
@@ -28,8 +28,6 @@ import org.springframework.test.web.servlet.client.RestTestClient;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.wiremock.spring.InjectWireMock;
-import se.digg.wallet.gateway.client.account.v0.model.SecurityEnvelopeResponse;
-import se.digg.wallet.gateway.client.account.v0.model.SecurityEnvelopesResponse;
 import se.digg.wallet.gateway.application.config.ApplicationConfig;
 import se.digg.wallet.gateway.application.config.SecurityConfig;
 import se.digg.wallet.gateway.application.controller.util.AuthUtil;
@@ -146,46 +144,6 @@ class AccountControllerAuthenticatedIntegrationTest {
         .jsonPath("$.title").exists()
         .jsonPath("$.detail").exists()
         .jsonPath("$.instance").exists();
-  }
-
-  @Test
-  void testGetSecurityEnvelopes() throws Exception {
-    var envelopeContent = "opaque-envelope-content";
-
-    var downstreamResponse = SecurityEnvelopesResponse.builder()
-        .items(java.util.List.of(
-            SecurityEnvelopeResponse.builder().content(envelopeContent).build()))
-        .build();
-
-    accountServer.stubFor(get("/v0/accounts/" + ACCOUNT_ID + "/security-envelopes")
-        .willReturn(aResponse()
-            .withStatus(200)
-            .withHeader("content-type", "application/json")
-            .withBody(objectMapper.writeValueAsString(downstreamResponse))));
-
-    var response = restClient.get()
-        .uri("/v0/accounts/security-envelopes")
-        .exchange();
-
-    response.expectStatus().isOk()
-        .expectBody()
-        .json("""
-            {
-              "items": [{ "content": "%s" }]
-            }
-            """.formatted(envelopeContent));
-  }
-
-  @Test
-  void testGetSecurityEnvelopesReturns500IfDownstreamFails() {
-    accountServer.stubFor(get("/v0/accounts/" + ACCOUNT_ID + "/security-envelopes")
-        .willReturn(aResponse().withStatus(400)));
-
-    var response = restClient.get()
-        .uri("/v0/accounts/security-envelopes")
-        .exchange();
-
-    response.expectStatus().isEqualTo(500);
   }
 
 }

--- a/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
@@ -99,9 +99,11 @@ class HsmControllerIntegrationTest {
     stubAccountHsmEndpoints();
   }
 
-  // The gateway now sources clientId + stateJws from the account on each HSM operation, so stub the
-  // account v0 endpoints HsmService calls: hsm-client-id (fetch/seed) and security-envelopes
-  // (stateJws fetch/write-back).
+  /*
+   * The gateway now sources clientId + stateJws from the account on each HSM operation, so stub the
+   * account v0 endpoints HsmService calls: hsm-client-id (fetch/seed) and security-envelopes
+   * (stateJws fetch/write-back).
+   */
   private void stubAccountHsmEndpoints() {
     accountServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v0/accounts/.*/hsm-client-id"))
         .willReturn(aResponse().withStatus(200).withHeader("content-type", "application/json")

--- a/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
@@ -190,13 +190,12 @@ class HsmControllerIntegrationTest {
             """
                 {
                   "status":"ok",
-                  "clientId":"%s",
                   "devAuthorizationCode":"%s",
                   "opaqueServerId":"server",
                   "serverJwsPublicKey":{"kty":"EC","kid":"kid","crv":"P-256","x":"x","y":"y","alg":null,"use":null}
                 }
                 """
-                .formatted(clientId, TEST_DEV_AUTH_CODE));
+                .formatted(TEST_DEV_AUTH_CODE));
   }
 
   @Test
@@ -338,10 +337,9 @@ class HsmControllerIntegrationTest {
               "status": "COMPLETE",
               "id": "%s",
               "result": "%s",
-              "resultUrl": null,
-              "stateJws": "%s"
+              "resultUrl": null
             }
-            """.formatted(requestId, TEST_JWT, testStateJws));
+            """.formatted(requestId, TEST_JWT));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/HsmControllerIntegrationTest.java
@@ -96,6 +96,27 @@ class HsmControllerIntegrationTest {
       requestId = UUID.randomUUID();
       clientId = UUID.randomUUID().toString();
     }
+    stubAccountHsmEndpoints();
+  }
+
+  // The gateway now sources clientId + stateJws from the account on each HSM operation, so stub the
+  // account v0 endpoints HsmService calls: hsm-client-id (fetch/seed) and security-envelopes
+  // (stateJws fetch/write-back).
+  private void stubAccountHsmEndpoints() {
+    accountServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v0/accounts/.*/hsm-client-id"))
+        .willReturn(aResponse().withStatus(200).withHeader("content-type", "application/json")
+            .withBody("{\"clientId\":\"" + clientId + "\"}")));
+    accountServer.stubFor(WireMock.post(WireMock.urlPathMatching("/v0/accounts/.*/hsm-client-id"))
+        .willReturn(aResponse().withStatus(201).withHeader("content-type", "application/json")
+            .withBody("{\"clientId\":\"" + clientId + "\"}")));
+    accountServer
+        .stubFor(WireMock.get(WireMock.urlPathMatching("/v0/accounts/.*/security-envelopes"))
+            .willReturn(aResponse().withStatus(200).withHeader("content-type", "application/json")
+                .withBody("{\"items\":[]}")));
+    accountServer
+        .stubFor(WireMock.post(WireMock.urlPathMatching("/v0/accounts/.*/security-envelopes"))
+            .willReturn(aResponse().withStatus(201).withHeader("content-type", "application/json")
+                .withBody("{\"content\":\"stored\"}")));
   }
 
   @Test
@@ -186,7 +207,6 @@ class HsmControllerIntegrationTest {
         .header("content-type", "application/json")
         .body(HsmRequest.builder()
             .outerRequestJws(TEST_JWT)
-            .clientId(clientId)
             .build())
         .exchange()
         .expectStatus()
@@ -306,7 +326,6 @@ class HsmControllerIntegrationTest {
         .header("content-type", "application/json")
         .body(HsmRequest.builder()
             .outerRequestJws(TEST_JWT)
-            .clientId(clientId)
             .build())
         .exchange()
         .expectStatus()
@@ -347,7 +366,6 @@ class HsmControllerIntegrationTest {
         .header("content-type", "application/json")
         .body(HsmRequest.builder()
             .outerRequestJws(TEST_JWT)
-            .clientId(clientId)
             .build())
         .exchange()
         .expectStatus()
@@ -394,7 +412,6 @@ class HsmControllerIntegrationTest {
         .header("content-type", "application/json")
         .body(HsmRequest.builder()
             .outerRequestJws(TEST_JWT)
-            .clientId(clientId)
             .build())
         .exchange()
         .expectStatus()


### PR DESCRIPTION
The gateway now sources clientId and stateJws from the authenticated account on each HSM operation instead of accepting them from clients, and persists a fresh stateJws whenever the HSM returns one.

* feat: add getHsmClientId/saveHsmClientId to AccountPort, adapter and service
* feat: fetch, inject and persist account credentials in HsmService
* feat: store HSMclientId and stateJws on the users account on HSM device-state registration
* feat: remove clientId and stateJws from the HsmRequest contract

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
