### PR TITLE
feat: return conflict problem when creating account duplicate

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/controller/DefaultExceptionHandler.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/DefaultExceptionHandler.java
@@ -7,6 +7,7 @@ package se.digg.wallet.gateway.application.controller;
 import static se.digg.wallet.gateway.application.controller.ProblemType.INTERNAL;
 import static se.digg.wallet.gateway.application.controller.ProblemType.REQUEST_ARGUMENT_NOT_VALID;
 import static se.digg.wallet.gateway.application.controller.ProblemType.REQUEST_VALIDATION_FAILURE;
+import static se.digg.wallet.gateway.application.controller.ProblemType.RESOURCE_ALREADY_EXISTS;
 import static se.digg.wallet.gateway.application.filter.LoggingFilter.MDC_TRANSACTION_ID;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +39,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import se.digg.wallet.gateway.api.v0.model.ProblemParameterResponse;
 import se.digg.wallet.gateway.api.v0.model.ProblemResponse;
+import se.digg.wallet.gateway.application.controller.exception.AccountAlreadyExistsException;
 import se.digg.wallet.gateway.application.controller.exception.RemoteResourceNotFoundException;
 
 @RestControllerAdvice
@@ -198,6 +200,25 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
         method, path, Map.of());
 
     return createResponseEntity(problemDetailResponse);
+  }
+
+  /*
+   * Handle AccountAlreadyExistsException. Occurs when account creation conflicts with an already
+   * existing account, e.g. the same device key kid is already in use.
+   */
+  @ExceptionHandler(AccountAlreadyExistsException.class)
+  public ResponseEntity<Object> handleAccountAlreadyExistsException(
+      AccountAlreadyExistsException e) {
+
+    var method = httpServletRequest.getMethod();
+    var path = httpServletRequest.getServletPath();
+    var problemResponse = buildProblemResponse(RESOURCE_ALREADY_EXISTS)
+        .detail(e.getLocalizedMessage())
+        .instance(path)
+        .build();
+
+    logWarn("Account already exists", method, path, null);
+    return createResponseEntity(problemResponse);
   }
 
   /*

--- a/src/main/java/se/digg/wallet/gateway/application/controller/ProblemType.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/ProblemType.java
@@ -5,6 +5,7 @@
 package se.digg.wallet.gateway.application.controller;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import java.net.URI;
@@ -23,6 +24,12 @@ public enum ProblemType {
       "Field value not valid",
       URI.create("/problem-details/field-validation-failure"),
       "Validation fails when processing the request body."),
+
+  RESOURCE_ALREADY_EXISTS(
+      CONFLICT,
+      "Resource already exists",
+      URI.create("/problem-details/resource-already-exists"),
+      "A resource with the same unique identifier already exists."),
 
   INTERNAL(
       INTERNAL_SERVER_ERROR,

--- a/src/main/java/se/digg/wallet/gateway/application/controller/exception/AccountAlreadyExistsException.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/exception/AccountAlreadyExistsException.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.gateway.application.controller.exception;
+
+/**
+ * Thrown when an account creation request conflicts with an already existing account, e.g. when an
+ * account already uses the same device key {@code kid}.
+ */
+public class AccountAlreadyExistsException extends WalletAccountException {
+
+  public AccountAlreadyExistsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/se/digg/wallet/gateway/application/controller/exception/WalletAccountException.java
+++ b/src/main/java/se/digg/wallet/gateway/application/controller/exception/WalletAccountException.java
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.gateway.application.controller.exception;
+
+public class WalletAccountException extends RuntimeException {
+  public WalletAccountException() {
+    super();
+  }
+
+  public WalletAccountException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/se/digg/wallet/gateway/infrastructure/account/client/WalletAccountAdapter.java
+++ b/src/main/java/se/digg/wallet/gateway/infrastructure/account/client/WalletAccountAdapter.java
@@ -5,7 +5,10 @@
 package se.digg.wallet.gateway.infrastructure.account.client;
 
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientResponseException;
+import se.digg.wallet.gateway.application.controller.exception.AccountAlreadyExistsException;
 import se.digg.wallet.gateway.client.account.v0.api.AccountApi;
 import se.digg.wallet.gateway.client.account.v0.model.AccountResponse;
 import se.digg.wallet.gateway.client.account.v0.model.HsmClientIdRequest;
@@ -40,9 +43,18 @@ public class WalletAccountAdapter implements AccountPort {
 
   @Override
   public Account createAccount(NewAccount newAccount) {
-    AccountResponse response =
-        accountApi.createAccount(accountClientMapper.toClientRequest(newAccount));
-    return accountClientMapper.toDomain(response);
+    try {
+      AccountResponse response =
+          accountApi.createAccount(accountClientMapper.toClientRequest(newAccount));
+      return accountClientMapper.toDomain(response);
+
+    } catch (RestClientResponseException e) {
+      if (HttpStatus.CONFLICT.value() == e.getStatusCode().value()) {
+        throw new AccountAlreadyExistsException("The Account conflicts with an existing one");
+      } else {
+        throw e;
+      }
+    }
   }
 
   @Override

--- a/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-client-gateway-openapi-v0.yaml
@@ -85,6 +85,14 @@ paths:
                 $ref: '#/components/schemas/CreateAccountResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: |
+            Duplicate account. Indicates a save conflict with an existing account having the same unique
+            account identifier. The deviceKey.kid value for new accounts must be unique.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
         'default':
           $ref: '#/components/responses/default'
 

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountApiComponentTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountApiComponentTest.java
@@ -26,6 +26,7 @@ import se.digg.wallet.gateway.api.v0.model.CreateAccountResponse;
 import se.digg.wallet.gateway.api.v0.model.EcJwkRequest;
 import se.digg.wallet.gateway.api.v0.model.ProblemResponse;
 import se.digg.wallet.gateway.api.v0.model.ProblemParameterResponse;
+import se.digg.wallet.gateway.application.controller.exception.AccountAlreadyExistsException;
 import se.digg.wallet.gateway.domain.model.account.Jwk;
 import se.digg.wallet.gateway.domain.model.account.JwkBuilder;
 import se.digg.wallet.gateway.domain.service.account.AccountService;
@@ -41,6 +42,7 @@ public class AccountApiComponentTest {
   private static final String EMAIL = "test.testsson@test.test";
   private static final String PHONE_NUMBER = "0700000000";
   private static final String VALIDATION_FAILURE = "/problem-details/field-validation-failure";
+  private static final String RESOURCE_EXISTS = "/problem-details/resource-already-exists";
   private static final UUID ACCOUNT_ID = UUID.fromString("61128b3c-ef55-4410-8dff-d8e8bf0cb9a7");
   private static final String KEY_ID = "26862913-ecd0-4d4d-a3d0-9271665d577e";
   private static final String TRANSACTION_ID = "a7240655-a568-41c8-8059-7b18859d5d88";
@@ -130,6 +132,28 @@ public class AccountApiComponentTest {
         .getResponseBody();
 
     assertProblemDetails(problemResponse, HttpStatus.BAD_REQUEST, VALIDATION_FAILURE, "email");
+  }
+
+  @Test
+  void creatingDuplicateAccountReturnsConflictProblem() {
+
+    var accountAlreadyExistsException = new AccountAlreadyExistsException("The message");
+
+    when(accountService.createAccount(any())).thenThrow(accountAlreadyExistsException);
+
+    var problemResponse = client.post()
+        .uri("/v0/accounts")
+        .body(CreateAccountRequest.builder()
+            .deviceKey(defaultKeyRequest().build())
+            .build())
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT.value())
+        .expectBody(ProblemResponse.class)
+        .returnResult()
+        .getResponseBody();
+
+    assertProblemDetails(problemResponse, HttpStatus.CONFLICT, RESOURCE_EXISTS, null);
   }
 
   @ParameterizedTest

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerIntegrationTest.java
@@ -7,23 +7,32 @@ package se.digg.wallet.gateway.application.controller;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
 import static se.digg.wallet.gateway.application.model.CreateAccountRequestDtoTestBuilder.EMAIL_ADDRESS;
 import static se.digg.wallet.gateway.application.model.CreateAccountRequestDtoTestBuilder.PERSONAL_IDENTITY_NUMBER;
 import static se.digg.wallet.gateway.application.model.CreateAccountRequestDtoTestBuilder.TELEPHONE_NUMBER;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import java.util.Map;
 import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.wiremock.spring.InjectWireMock;
 import se.digg.wallet.gateway.api.v0.model.CreateAccountRequest;
+import se.digg.wallet.gateway.api.v0.model.CreateAccountResponse;
+import se.digg.wallet.gateway.api.v0.model.ProblemResponse;
 import se.digg.wallet.gateway.application.config.ApplicationConfig;
 import se.digg.wallet.gateway.application.config.SecurityConfig;
 import se.digg.wallet.gateway.application.controller.util.WalletAccountMock;
@@ -42,6 +51,9 @@ import tools.jackson.databind.ObjectMapper;
 @AutoConfigureRestTestClient
 class AccountControllerIntegrationTest {
 
+  private static final UUID ACCOUNT_ID = UUID.fromString("61128b3c-ef55-4410-8dff-d8e8bf0cb9a7");
+  private static final String KEY_ID = "26862913-ecd0-4d4d-a3d0-9271665d577e";
+
   @Autowired
   private RestTestClient restClient;
 
@@ -59,6 +71,11 @@ class AccountControllerIntegrationTest {
 
   @InjectWireMock(WalletAccountMock.NAME)
   private WireMockServer server;
+
+  @BeforeEach
+  void startup() {
+    WireMock.resetAllScenarios();
+  }
 
   @Test
   void testCreateAccount() throws Exception {
@@ -117,6 +134,86 @@ class AccountControllerIntegrationTest {
 
     response.expectStatus()
         .isEqualTo(400);
+  }
+
+  @Test
+  void creatingDuplicateAccountReturnsConflictProblem() {
+
+    var expectedRequest = AccountRequest.builder()
+        .deviceKey(KeyRequest.builder()
+            .kty("KTY")
+            .kid(KEY_ID)
+            .alg("ALG")
+            .use("USE")
+            .crv("CRV")
+            .x("X")
+            .y("Y")
+            .build())
+        .build();
+
+    var expectedResponse = AccountResponse.builder()
+        .id(ACCOUNT_ID)
+        .deviceKey(KeyResponse.builder()
+            .kty("KTY").kid(KEY_ID).alg("ALG").use("USE")
+            .crv("CRV").x("X").y("Y").build())
+        .build();
+
+    var scenarioName = "Create Duplicate Account Sequence";
+
+    // First request - create new account
+    stubFor(post("/v0/accounts")
+        .inScenario(scenarioName).whenScenarioStateIs(Scenario.STARTED)
+        .withRequestBody(equalToJson(objectMapper.writeValueAsString(expectedRequest), true, true))
+        .willReturn(aResponse()
+            .withStatus(201)
+            .withHeader("content-type", "application/json")
+            .withBody(objectMapper.writeValueAsString(expectedResponse)))
+        .willSetStateTo("Account Created"));
+
+    // Second request - fails with duplicate account
+    stubFor(
+        post("/v0/accounts")
+            .inScenario(scenarioName)
+            .whenScenarioStateIs("Account Created")
+            .withRequestBody(
+                equalToJson(objectMapper.writeValueAsString(expectedRequest), true, true))
+            .willReturn(
+                aResponse()
+                    .withStatus(409)
+                    .withHeader("content-type", "application/problem+json")
+                    .withBody(
+                        objectMapper.writeValueAsString(
+                            ProblemResponse.builder()
+                                .status(HttpStatus.CONFLICT.value())
+                                .title(HttpStatus.CONFLICT.getReasonPhrase())
+                                .build())))
+            .willSetStateTo("Account Conflict"));
+
+    var createdAccount = restClient.post()
+        .uri("v0/accounts")
+        .header(SecurityConfig.API_KEY_HEADER, applicationConfig.apisecret())
+        .body(expectedRequest)
+        .exchange()
+        .expectStatus().isCreated()
+        .expectBody(CreateAccountResponse.class)
+        .returnResult()
+        .getResponseBody();
+
+    assertThat(createdAccount).isNotNull();
+    assertThat(createdAccount.getAccountId()).isNotNull().isEqualTo(ACCOUNT_ID);
+
+    var problemResponse = restClient.post()
+        .uri("v0/accounts")
+        .header(SecurityConfig.API_KEY_HEADER, applicationConfig.apisecret())
+        .body(expectedRequest)
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.CONFLICT.value())
+        .expectBody(ProblemResponse.class)
+        .returnResult()
+        .getResponseBody();
+
+    assertThat(problemResponse).isNotNull();
+    assertThat(problemResponse.getStatus()).isNotNull().isEqualTo(HttpStatus.CONFLICT.value());
   }
 
   private UUID stubAccountCreationWithNullValues() throws Exception {


### PR DESCRIPTION
# Pull Request Description

Respond with http status 409 Conflict and a defined problem type when creating a duplicate account.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
