### PR TITLE
Feat/api key rotation

### DIFF
--- a/src/main/java/se/digg/wallet/gateway/application/config/ApplicationConfig.java
+++ b/src/main/java/se/digg/wallet/gateway/application/config/ApplicationConfig.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public record ApplicationConfig(
     @NotBlank String apisecret,
+    String oldapisecret,
     @NotEmpty List<String> publicPaths,
     @NotEmpty List<String> apiKeyPaths,
     @NotNull Walletprovider walletprovider,

--- a/src/main/java/se/digg/wallet/gateway/application/config/SecurityConfig.java
+++ b/src/main/java/se/digg/wallet/gateway/application/config/SecurityConfig.java
@@ -32,25 +32,31 @@ public class SecurityConfig {
 
   public static final String API_KEY_HEADER = "X-API-KEY";
 
-  private final String apiSecret;
-  private final String oldApiSecret;
+  private final byte[] apiSecret;
+  private final byte[] oldApiSecret;
   private final List<String> publicPaths;
   private final List<String> apiKeyPaths;
   private final AntPathMatcher pathMatcher;
 
   public SecurityConfig(
       ApplicationConfig applicationConfig) {
-    this.apiSecret = Objects.requireNonNull(applicationConfig.apisecret());
-    this.oldApiSecret = applicationConfig.oldapisecret();
+    this.apiSecret = toBytes(Objects.requireNonNull(applicationConfig.apisecret()));
+    this.oldApiSecret = toBytes(applicationConfig.oldapisecret());
     this.publicPaths = applicationConfig.publicPaths();
     this.apiKeyPaths = applicationConfig.apiKeyPaths();
     this.pathMatcher = new AntPathMatcher();
+  }
+
+  private static byte[] toBytes(String secret) {
+    return secret == null || secret.isBlank() ? null : secret.getBytes(StandardCharsets.UTF_8);
   }
 
   @Bean
   public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) {
     httpSecurity
         .csrf(AbstractHttpConfigurer::disable)
+        // Unused by this stateless API (no redirect-based login flow); disabling it avoids
+        // per-request session mishits against Valkey.
         .requestCache(RequestCacheConfigurer::disable)
         .authorizeHttpRequests((authorize) -> authorize
             .anyRequest()
@@ -102,12 +108,11 @@ public class SecurityConfig {
     return constantTimeEquals(apiSecret, header) || constantTimeEquals(oldApiSecret, header);
   }
 
-  private boolean constantTimeEquals(String secret, String header) {
-    if (secret == null || secret.isBlank()) {
+  private boolean constantTimeEquals(byte[] secret, String header) {
+    if (secret == null) {
       return false;
     }
-    return MessageDigest.isEqual(
-        secret.getBytes(StandardCharsets.UTF_8), header.getBytes(StandardCharsets.UTF_8));
+    return MessageDigest.isEqual(secret, header.getBytes(StandardCharsets.UTF_8));
   }
 
   boolean isPublicPath(HttpServletRequest request) {

--- a/src/main/java/se/digg/wallet/gateway/application/config/SecurityConfig.java
+++ b/src/main/java/se/digg/wallet/gateway/application/config/SecurityConfig.java
@@ -5,6 +5,8 @@
 package se.digg.wallet.gateway.application.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +32,7 @@ public class SecurityConfig {
   public static final String API_KEY_HEADER = "X-API-KEY";
 
   private final String apiSecret;
+  private final String oldApiSecret;
   private final List<String> publicPaths;
   private final List<String> apiKeyPaths;
   private final AntPathMatcher pathMatcher;
@@ -37,6 +40,7 @@ public class SecurityConfig {
   public SecurityConfig(
       ApplicationConfig applicationConfig) {
     this.apiSecret = Objects.requireNonNull(applicationConfig.apisecret());
+    this.oldApiSecret = applicationConfig.oldapisecret();
     this.publicPaths = applicationConfig.publicPaths();
     this.apiKeyPaths = applicationConfig.apiKeyPaths();
     this.pathMatcher = new AntPathMatcher();
@@ -88,8 +92,20 @@ public class SecurityConfig {
     };
   }
 
-  private boolean hasValidApiKey(HttpServletRequest request) {
-    return apiSecret.equals(request.getHeader(API_KEY_HEADER));
+  boolean hasValidApiKey(HttpServletRequest request) {
+    var header = request.getHeader(API_KEY_HEADER);
+    if (header == null) {
+      return false;
+    }
+    return constantTimeEquals(apiSecret, header) || constantTimeEquals(oldApiSecret, header);
+  }
+
+  private boolean constantTimeEquals(String secret, String header) {
+    if (secret == null || secret.isBlank()) {
+      return false;
+    }
+    return MessageDigest.isEqual(
+        secret.getBytes(StandardCharsets.UTF_8), header.getBytes(StandardCharsets.UTF_8));
   }
 
   boolean isPublicPath(HttpServletRequest request) {

--- a/src/main/java/se/digg/wallet/gateway/application/config/SecurityConfig.java
+++ b/src/main/java/se/digg/wallet/gateway/application/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.util.AntPathMatcher;
@@ -50,6 +51,7 @@ public class SecurityConfig {
   public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) {
     httpSecurity
         .csrf(AbstractHttpConfigurer::disable)
+        .requestCache(RequestCacheConfigurer::disable)
         .authorizeHttpRequests((authorize) -> authorize
             .anyRequest()
             .access(gatewayAuthorizationMgr()));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@
 # Application Properties
 properties:
   apisecret: secret
+  oldapisecret: secret2
   # Truly public paths - no authentication required
   public-paths:
     - "/"
@@ -14,7 +15,6 @@ properties:
     - "/swagger-ui.html"
     - "/swagger-ui/**"
     - "/public/**"
-    - "/wua"
   # Paths that require a valid API key (but not challenge-response auth)
   api-key-paths:
     - "/v0/accounts"

--- a/src/test/java/se/digg/wallet/gateway/application/config/ChallengeResponseAuthorizationMgrTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/config/ChallengeResponseAuthorizationMgrTest.java
@@ -101,6 +101,51 @@ class ChallengeResponseAuthorizationMgrTest {
     assertThat(securityConfig.isPublicPath(request)).isFalse();
   }
 
+  @Test
+  void acceptsOldApiKeyWhileConfigured() {
+    ApplicationConfig applicationConfig = mock(ApplicationConfig.class);
+    when(applicationConfig.apisecret()).thenReturn("my_secret_key");
+    when(applicationConfig.oldapisecret()).thenReturn("my_old_secret_key");
+    when(applicationConfig.publicPaths()).thenReturn(List.of("/public/**"));
+    when(applicationConfig.apiKeyPaths()).thenReturn(List.of("/accounts"));
+    var securityConfig = new SecurityConfig(applicationConfig);
+
+    var request = mock(HttpServletRequest.class);
+    when(request.getHeader(SecurityConfig.API_KEY_HEADER)).thenReturn("my_old_secret_key");
+
+    assertThat(securityConfig.hasValidApiKey(request)).isTrue();
+  }
+
+  @Test
+  void rejectsOldApiKeyWhenMisconfiguredAsBlank() {
+    ApplicationConfig applicationConfig = mock(ApplicationConfig.class);
+    when(applicationConfig.apisecret()).thenReturn("my_secret_key");
+    when(applicationConfig.oldapisecret()).thenReturn("  ");
+    when(applicationConfig.publicPaths()).thenReturn(List.of("/public/**"));
+    when(applicationConfig.apiKeyPaths()).thenReturn(List.of("/accounts"));
+    var securityConfig = new SecurityConfig(applicationConfig);
+
+    var request = mock(HttpServletRequest.class);
+    when(request.getHeader(SecurityConfig.API_KEY_HEADER)).thenReturn("  ");
+
+    assertThat(securityConfig.hasValidApiKey(request)).isFalse();
+  }
+
+  @Test
+  void rejectsOldApiKeyOnceRotationIsCompleted() {
+    ApplicationConfig applicationConfig = mock(ApplicationConfig.class);
+    when(applicationConfig.apisecret()).thenReturn("my_secret_key");
+    when(applicationConfig.oldapisecret()).thenReturn(null);
+    when(applicationConfig.publicPaths()).thenReturn(List.of("/public/**"));
+    when(applicationConfig.apiKeyPaths()).thenReturn(List.of("/accounts"));
+    var securityConfig = new SecurityConfig(applicationConfig);
+
+    var request = mock(HttpServletRequest.class);
+    when(request.getHeader(SecurityConfig.API_KEY_HEADER)).thenReturn("my_old_secret_key");
+
+    assertThat(securityConfig.hasValidApiKey(request)).isFalse();
+  }
+
   private Supplier<Authentication> asSupplier(Authentication auth) {
     return () -> auth;
   }

--- a/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/AccountControllerIntegrationTest.java
@@ -89,6 +89,30 @@ class AccountControllerIntegrationTest {
   }
 
   @Test
+  void testCreateAccountWithOldApiKeyIsAccepted() throws Exception {
+    var generatedAccountId = stubAccountCreation();
+
+    var response = restClient.post()
+        .uri("/v0/accounts")
+        .header(SecurityConfig.API_KEY_HEADER, applicationConfig.oldapisecret())
+        .body(CreateAccountRequestTestBuilder.withDefaults().build())
+        .exchange();
+
+    expectCreatedWithAccountId(response, generatedAccountId);
+  }
+
+  @Test
+  void testCreateAccountWithInvalidApiKeyIsRejected() {
+    var response = restClient.post()
+        .uri("/v0/accounts")
+        .header(SecurityConfig.API_KEY_HEADER, "not-a-valid-key")
+        .body(CreateAccountRequestTestBuilder.withDefaults().build())
+        .exchange();
+
+    response.expectStatus().isForbidden();
+  }
+
+  @Test
   void testCreateAccountWithEmptyEmailAndSsn() throws Exception {
     var generatedAccountId = stubAccountCreationWithNullValues();
     var accountWithEmptyEmailAndSsn = CreateAccountRequestTestBuilder.withDefaults()

--- a/src/test/java/se/digg/wallet/gateway/application/controller/WuaControllerIntegrationTest.java
+++ b/src/test/java/se/digg/wallet/gateway/application/controller/WuaControllerIntegrationTest.java
@@ -130,7 +130,7 @@ class WuaControllerIntegrationTest {
   }
 
   @Test
-  void testRequestingWuaNotAuthenticatedReturnsBadRequest() {
+  void testRequestingWuaNotAuthenticatedReturnsForbidden() {
     authenticated = false;
 
     RestTestClient unauthenticatedClient = RestTestClient.bindToServer()
@@ -141,12 +141,14 @@ class WuaControllerIntegrationTest {
         .uri("/wua" + "?nonce=" + TEST_NONCE)
         .exchange();
 
+    // /wua is behind the full-auth tier (API key + challenge-response session), so
+    // Spring Security's gatewayAuthorizationMgr() rejects this before it reaches the controller.
     response.expectStatus()
-        .isBadRequest();
+        .isForbidden();
   }
 
   @Test
-  void testRequestingWuaNoAccountIdReturnsUnAuthorized() {
+  void testRequestingWuaNoAccountIdReturnsForbidden() {
     AuthUtil.ACCOUNT_ID = null;
 
     // Create a new RestTestClient without authentication (no session header)
@@ -158,10 +160,10 @@ class WuaControllerIntegrationTest {
         .uri("/wua" + "?nonce=" + TEST_NONCE)
         .exchange();
 
-    // Spring Security's challengeResponseAuthorizationMgr() blocks requests that don't have
+    // Spring Security's gatewayAuthorizationMgr() blocks requests that don't have
     // a valid ChallengeResponseAuthentication in the session, returning 403 Forbidden
     response.expectStatus()
-        .isBadRequest();
+        .isForbidden();
 
     // Revert for other tests using AuthUtil.ACCOUNT_ID.
     AuthUtil.ACCOUNT_ID = ACCOUNT_ID;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,6 +9,7 @@ spring:
 # Application Properties
 properties:
   apisecret: my_secret_key
+  oldapisecret: my_old_secret_key
   public-paths:
     - "/"
     - "/actuator/**"
@@ -18,7 +19,6 @@ properties:
     - "/swagger-ui.html"
     - "/swagger-ui/**"
     - "/public/**"
-    - "/wua"
   api-key-paths:
     - "/v0/accounts"
   walletprovider:


### PR DESCRIPTION
Rotation flow:
1. Move the current value of apisecret into oldapisecret, set apisecret to the new key, redeploy. Both keys now work — no downtime for clients still holding the old key.
2. Once all clients have picked up the new key (or enough time has passed), clear/unset oldapisecret in config and redeploy. Only the new key works from then on.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
